### PR TITLE
Add support for excluding speficied languages from stats

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let filtered_langs: HashMap<String, u64> = lang_map
                     .clone()
                     .into_iter()
-                    .filter(|(lang, _)| !excluded_languages.contains(lang))
+                    .filter(|(lang, _)| {
+                        !excluded_languages.iter().any(|excl| excl.eq_ignore_ascii_case(lang))
+                    })
                     .collect();
 
                 for (lang, bytes) in filtered_langs {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,10 @@ struct Args {
     /// GitHub Token
     #[clap(short, long, env = "GITHUB_TOKEN")]
     token: String,
+
+    /// Comma-separated string-list of languages to exclude
+    #[clap(short, long, env = "EXCLUDED_LANGUAGES", default_value = "")]
+    excluded_languages: String,
 }
 
 #[tokio::main]
@@ -26,6 +30,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenv().ok();
     let args = Args::parse();
     let token = args.token;
+    let excluded_languages: Vec<String> = args
+        .excluded_languages
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
     let client = Client::new();
     let mut total_lang_map: HashMap<String, u64> = HashMap::new();
     let user_name = get_username(&token).await?;
@@ -71,7 +81,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 let lang_map: HashMap<String, u64> = lang_res.json().await?;
 
-                for (lang, bytes) in lang_map {
+                let filtered_langs: HashMap<String, u64> = lang_map
+                    .clone()
+                    .into_iter()
+                    .filter(|(lang, _)| !excluded_languages.contains(lang))
+                    .collect();
+
+                for (lang, bytes) in filtered_langs {
                     *total_lang_map.entry(lang).or_insert(0) += bytes;
                 }
             }


### PR DESCRIPTION
Hello, I liked your project and would like to contribute by adding support for excluding certain languages the user doesn't want to show on their stats as an optional parameter.

To exclude languages just need to pass `--excluded-languages` or `EXCLUDED_LANGUAGES` in args or .env, respectively.

### Usage Example
`.env file`

```bash
EXCLUDED_LANGUAGES="Jupyter Notebook, HTML, CSS"
```

`CLI`
```bash
./self-reposcope --token <TOKEN> --excluded-languages "Jupyter Notebook, HTML, CSS"
```
PS: Languages must be separated by commas. Wrap in quotes if any language name contains spaces or it will not be able to identify it.

It will then filter out the languages and generate the SVG without displaying them.

#### Before:
![full_languages](https://github.com/user-attachments/assets/edb66ce8-1d8a-442e-b76d-9ee673486efc)

#### After (with exclusions applied):
![full_languages](https://github.com/user-attachments/assets/460a8323-82b7-4877-abf6-bd1aac608928)
